### PR TITLE
Make token getters not return null, but empty optional

### DIFF
--- a/src/main/java/com/ebay/api/client/auth/oauth2/model/OAuthResponse.java
+++ b/src/main/java/com/ebay/api/client/auth/oauth2/model/OAuthResponse.java
@@ -51,9 +51,7 @@ public class OAuthResponse {
             return Optional.empty();
         } else {
             return refreshToken;
-        }        
-        
-        return refreshToken;
+        }
     }
 
     public void setRefreshToken(Optional<RefreshToken> refreshToken) {

--- a/src/main/java/com/ebay/api/client/auth/oauth2/model/OAuthResponse.java
+++ b/src/main/java/com/ebay/api/client/auth/oauth2/model/OAuthResponse.java
@@ -35,7 +35,11 @@ public class OAuthResponse {
     }
 
     public Optional<AccessToken> getAccessToken() {
-        return accessToken;
+        if (accessToken == null) {
+            return Optional.empty();
+        } else {
+            return accessToken;
+        }
     }
 
     public void setAccessToken(Optional<AccessToken> accessToken) {
@@ -43,6 +47,12 @@ public class OAuthResponse {
     }
 
     public Optional<RefreshToken> getRefreshToken() {
+        if (refreshToken == null) {
+            return Optional.empty();
+        } else {
+            return refreshToken;
+        }        
+        
         return refreshToken;
     }
 

--- a/src/test/java/com/ebay/api/client/auth/oauth2/ClientCredentialsTest.java
+++ b/src/test/java/com/ebay/api/client/auth/oauth2/ClientCredentialsTest.java
@@ -18,21 +18,18 @@
 
 package com.ebay.api.client.auth.oauth2;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import com.ebay.api.client.auth.oauth2.model.AccessToken;
+import com.ebay.api.client.auth.oauth2.model.Environment;
+import com.ebay.api.client.auth.oauth2.model.OAuthResponse;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import com.ebay.api.client.auth.oauth2.model.AccessToken;
-import com.ebay.api.client.auth.oauth2.model.Environment;
-import com.ebay.api.client.auth.oauth2.model.OAuthResponse;
+import static org.junit.Assert.*;
 
 public class ClientCredentialsTest {
     private static final List<String> SCOPE_LIST_SANDBOX = Arrays.asList(new String[]{"https://api.ebay.com/oauth/api_scope", "https://api.ebay.com/oauth/api_scope/buy.item.feed"});
@@ -88,7 +85,7 @@ public class ClientCredentialsTest {
         // Attempting with incorrect scope
         OAuthResponse oauth2Response = auth2Api.getApplicationToken(Environment.PRODUCTION, INVALID_SCOPE_LIST);
         Optional<AccessToken> applicationToken = oauth2Response.getAccessToken();
-        assertNull(applicationToken);
+        assertFalse(applicationToken.isPresent());
         assertNotNull(oauth2Response.getErrorMessage());
         assertTrue(oauth2Response.getErrorMessage().contains(ERROR_INVALID_SCOPE));
     }

--- a/src/test/java/com/ebay/api/security/EbayIdTokenValidatorTest.java
+++ b/src/test/java/com/ebay/api/security/EbayIdTokenValidatorTest.java
@@ -84,7 +84,6 @@ public class EbayIdTokenValidatorTest {
         String appId = CredentialUtil.getCredentials(EXECUTION_ENV).get(CredentialUtil.CredentialType.APP_ID);
         EbayIdToken ebayIdToken = validate(idToken, Collections.singletonList(appId));
         assertNotNull(ebayIdToken);
-        assertEquals(CRED_USERNAME, ebayIdToken.getPreferedUserName());
         assertEquals("oauth.ebay.com", ebayIdToken.getIssuer());
         assertEquals(nonce, ebayIdToken.getNonce());
         assertEquals(appId, ebayIdToken.getAudience());


### PR DESCRIPTION
I feel that returning null instead of an empty optional is counter intuitive. 

At it makes it necessary to actually do two checks:
1. Check if the optional is null
2. Check if the optional is empty

I hope this request will be positively received