### PR TITLE
Addressing resource leak raised in issue #28

### DIFF
--- a/src/main/java/com/ebay/api/client/auth/oauth2/OAuth2Api.java
+++ b/src/main/java/com/ebay/api/client/auth/oauth2/OAuth2Api.java
@@ -83,6 +83,7 @@ public class OAuth2Api {
         if (response.isSuccessful()) {
             logger.debug("Network call to generate new token is successfull");
             OAuthResponse oAuthResponse = OAuth2Util.parseApplicationToken(response.body().string());
+            response.close();
             AccessToken accessToken = oAuthResponse.getAccessToken().get();
             appAccessToken = new TimedCacheValue(oAuthResponse, new DateTime(accessToken.getExpiresOn()));
             appAccessTokenMap.put(environment, appAccessToken);
@@ -134,7 +135,9 @@ public class OAuth2Api {
 
         Response response = client.newCall(request).execute();
         if (response.isSuccessful()) {
-            return OAuth2Util.parseUserToken(response.body().string());
+            String responseBody = response.body().string();
+            response.close();
+            return OAuth2Util.parseUserToken(responseBody);
         } else {
             return OAuth2Util.handleError(response);
         }

--- a/src/main/java/com/ebay/api/client/auth/oauth2/OAuth2Util.java
+++ b/src/main/java/com/ebay/api/client/auth/oauth2/OAuth2Util.java
@@ -75,6 +75,7 @@ class OAuth2Util {
 
     static OAuthResponse handleError(Response response) throws IOException {
         String errorMessage = response.body().string();
+        response.close();
         return new OAuthResponse(errorMessage);
     }
 }


### PR DESCRIPTION
When we are finished with processing of response from okhttp3 client we need to close it to allow the associated resources to be freed.

Closes #28 