### PR TITLE
Module Not Found Error in javax.xml.bind

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,13 @@
             <artifactId>commons-codec</artifactId>
             <version>1.13</version>
         </dependency>
+      
+      	<!-- https://mvnrepository.com/artifact/javax.xml.bind/jaxb-api -->
+        <dependency>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+          <version>2.3.0</version>
+        </dependency>
 
         <!-- TEST ONLY DEPENDENCIES -->
         <!-- https://mvnrepository.com/artifact/junit/junit -->


### PR DESCRIPTION
The code compiles successfully in command line however when we import the project in Intellij or Eclipse it creates an Error on the import statement
import javax.xml.bind.annotation.XmlRootElement;
in src>main>java>com>ebay>API>client>auth>oauth2>model>TokenResponse.java

The project compiles successfully after adding this dependency : https://mvnrepository.com/artifact/javax.xml.bind/jaxb-api/2.3.0